### PR TITLE
updated regexps to include more cases

### DIFF
--- a/lib/i18n_tools/scanner.rb
+++ b/lib/i18n_tools/scanner.rb
@@ -1,7 +1,7 @@
 module I18nTools
   class Scanner
-    VIEW_REGEXPS = [/[^\w]t\(\"(.*?)\".*?\)/, /[^\w]t\(\'(.*?)\'.*?\)/]
-    CODE_REGEXPS = [/I18n\.t\(\"(.*?)\".*?\)/, /I18n\.t\(\'(.*?)\'.*?\)/]
+    VIEW_REGEXPS = [/[^\w]t\ *\(\"(.*?)\".*?\)/, /[^\w]t\ *\(\'(.*?)\'.*?\)/, /[^\w]t\ *\(\:([^\,\ ]+).*\)/, /[^\w]t\ \"(.*)\"/, /[^\w]t\ \'(.*)\'/, /[^\w]t\ +\:([^\,\ ]+)/]
+    CODE_REGEXPS = VIEW_REGEXPS
     
     cattr_accessor :file_types
     self.file_types = ['controllers', 'helpers', 'models']


### PR DESCRIPTION
Include these cases:
1. Code t() methods without I18n prefix
2. With/without (Parentheses)
3. With colon (:) instead of "/'

still missing: t inside another t, many t's in the same line (but you can diffrentiate them by syntax - :, ', ", () etc.
