### PR TITLE
Remove trailing wihtespace in yml output

### DIFF
--- a/tasks/i18n_tools.rake
+++ b/tasks/i18n_tools.rake
@@ -43,7 +43,7 @@ namespace :translations do
       content = File.read(file)
       parts = content.split("---").map { |part| YAML.load(part) }
       result = parts.inject({}) { |result, hash| result.deeper_merge(hash) }
-      File.open(file, 'w') { |f| f.puts(result.ya2yaml) }
+      File.open(file, 'w') { |f| f.puts(result.ya2yaml.gsub(/\s+$/, '')) }
     end
   end
 end


### PR DESCRIPTION
- Removes any trailing whitespaces from yml files in rake translations:merge
